### PR TITLE
feat: added function `Slice.Replace`

### DIFF
--- a/example_test.go
+++ b/example_test.go
@@ -158,6 +158,28 @@ func ExampleSlice_Insert() {
 	// [one two three four]
 }
 
+func ExampleSlice_Replace() {
+	s := slice.FromRaw([]string{"one", "two", "two", "two", "two"})
+	s.Replace(2, "three", "four", "five")
+	fmt.Println(s)
+
+	// Output:
+	// [one two three four five]
+}
+
+func ExampleSlice_Replace_false() {
+	s := slice.FromRaw([]string{"one", "two", "two", "two"})
+
+	// cannot replace 3 elements starting from index 2
+	// the given slice does not have enough elements
+	fmt.Println(s.Replace(2, "three", "four", "five"))
+	fmt.Println(s)
+
+	// Output:
+	// false
+	// [one two two two]
+}
+
 func ExampleSlice_Insert_false() {
 	s := slice.FromRaw[string](nil)
 	fmt.Println(s.Insert(1, "one")) // the highest possible index to insert == len(s)

--- a/slice.go
+++ b/slice.go
@@ -137,6 +137,22 @@ func (s *Slice[T]) Insert(index int, v ...T) (ok bool) {
 	return true
 }
 
+// Replace replaces s[index:index+len(v)] with v.
+// It does not succeed when the given slice does not have enough elements to be replaced..
+//
+//	s := slice.FromRaw([]string{"one", "two", "two", "two", "two"})
+//	s.Replace(2, "three", "four", "five")
+//	fmt.Println(s) // [one two three four five]
+func (s *Slice[T]) Replace(index int, v ...T) (ok bool) {
+	if index < 0 || index+len(v) > len(*s) {
+		return false
+	}
+
+	copy((*s)[index:index+len(v)], v)
+
+	return true
+}
+
 // Clone returns a new slice with the same length and copies to it all the elements from the existing slice.
 func (s *Slice[T]) Clone() Slice[T] {
 	if *s == nil {

--- a/slice.go
+++ b/slice.go
@@ -138,7 +138,7 @@ func (s *Slice[T]) Insert(index int, v ...T) (ok bool) {
 }
 
 // Replace replaces s[index:index+len(v)] with v.
-// It does not succeed when the given slice does not have enough elements to be replaced..
+// It does not succeed when the given slice does not have enough elements to be replaced.
 //
 //	s := slice.FromRaw([]string{"one", "two", "two", "two", "two"})
 //	s.Replace(2, "three", "four", "five")


### PR DESCRIPTION
## Summary by Sourcery

Add the `Slice.Replace` function to allow replacing a segment of a slice with new elements, and include tests to validate its functionality.

New Features:
- Introduce the `Slice.Replace` function to replace a segment of a slice with new elements.

Tests:
- Add tests for the `Slice.Replace` function to verify its behavior when replacing elements and when the replacement is not possible.