### PR TITLE
chore: `clear` -> `clearSlice`

### DIFF
--- a/clear_polyfill.go
+++ b/clear_polyfill.go
@@ -2,7 +2,7 @@ package slice
 
 // The function [clear] has been introduced in GO 1.21.
 // See https://tip.golang.org/doc/go1.21#language.
-func clear[S ~[]T, T any](in S) {
+func clearSlice[S ~[]T, T any](in S) {
 	var x T
 
 	for i := 0; i < len(in); i++ {

--- a/slice.go
+++ b/slice.go
@@ -32,7 +32,7 @@ func (s *Slice[T]) Shift() (_ T, ok bool) {
 	}
 
 	start := *s
-	defer clear(start[0:1])
+	defer clearSlice(start[0:1])
 
 	r, *s = (*s)[0], (*s)[1:]
 
@@ -73,7 +73,7 @@ func (s *Slice[T]) Pop() (_ T, ok bool) {
 	}
 
 	start := *s
-	defer clear(start[len(start)-1:])
+	defer clearSlice(start[len(start)-1:])
 
 	r, *s = (*s)[len(*s)-1], (*s)[:len(*s)-1]
 
@@ -109,7 +109,7 @@ func (s *Slice[T]) Delete(index int, length int) (ok bool) {
 	}
 
 	start := *s
-	defer clear(start[len(start)-length:])
+	defer clearSlice(start[len(start)-length:])
 
 	*s = append((*s)[:index], (*s)[index+length:]...)
 
@@ -195,7 +195,7 @@ func (s *Slice[T]) Filter(keep func(index int, val T) bool) {
 		}
 	}
 
-	clear((*s)[len(n):])
+	clearSlice((*s)[len(n):])
 
 	*s = n
 }


### PR DESCRIPTION
## Summary by Sourcery

Enhancements:
- Rename the function `clear` to `clearSlice` for better clarity and to avoid potential conflicts with Go 1.21's built-in `clear` function.