### PR TITLE
docs: README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -268,6 +268,7 @@ fmt.Println(val)  // Output: 5
 - `Len()`: Get the length of the slice.
 - `Cap()`: Get the capacity of the slice.
 - `Empty()`: Check if the slice is empty.
+- `Raw()`: Retrieve the underlying Go slice.
 
 ## License
 


### PR DESCRIPTION
## Summary by Sourcery

Documentation:
- Add documentation for the `Raw()` method in the README.md file.